### PR TITLE
🔥 hotfix(UI, form): 사용자 경험 및 폼 상태 관리 개선

### DIFF
--- a/src/components/my/MyMainScreen.jsx
+++ b/src/components/my/MyMainScreen.jsx
@@ -105,8 +105,8 @@ const ProfileSection = styled.div`
     flex-shrink: 0;
 
     @media (max-width: 768px) {
-        padding: 0.5rem 0;
-        gap: 0.5rem;
+        padding: 1rem 0;
+        gap: 1rem;
     }
 `
 

--- a/src/components/my/modify/ModifyScreen.jsx
+++ b/src/components/my/modify/ModifyScreen.jsx
@@ -15,8 +15,8 @@ function ModifyScreen() {
 
         mutate(currentUserNickname, {
             onSuccess: () => {
-                alert("닉네임이 수정되었습니다!");
-                console.log(currentUserNickname)
+                alert("프로필이 수정되었습니다!");
+                navigate("/mypage");
             },
             onError: () => {
                 alert("닉네임 수정 실패");

--- a/src/components/my/profile/StoreInfoCard.jsx
+++ b/src/components/my/profile/StoreInfoCard.jsx
@@ -10,11 +10,8 @@ import ErrorState from "../../loading/ErrorState.jsx";
 function StoreInfoCard() {
     const navigate = useNavigate();
     const { user } = useUserStore();
-    console.log(user)
     const mainStore = user?.stores?.find(store => store.store_id === user.main_store_id);
-    console.log(mainStore)
     const { data: storeData, isPending, isError } = useGetMainStore(mainStore?.store_id);
-    console.log(storeData)
 
     const handleEditClick = () => {
         navigate("/mypage/modify");
@@ -70,12 +67,14 @@ const Container = styled.div`
     justify-content: flex-start;
     align-items: center;
     padding: 0 2rem;
+    gap: 1rem;
 `;
 const InfoSection = styled.div`
   display: flex;
     width: 100%;
   flex-direction: column;
   gap: 1rem;
+    padding-top: 1rem;
 `;
 
 const Field = styled.div`

--- a/src/components/postNew/PostNewScreen.jsx
+++ b/src/components/postNew/PostNewScreen.jsx
@@ -1,22 +1,22 @@
 import styled from "styled-components";
 import StepOne from "./step/StepOne.jsx";
 import StepTwo from "./step/StepTwo.jsx";
-import StepThree from "./step/StepThree.jsx";
-import useFormStore from "../../store/useFormStore.js";
-import StepFour from "./step/StepFour.jsx";
 import StepFive from "./step/StepFive.jsx";
+import useFormStore from "../../store/useFormStore.js";
+import StepSix from "./step/StepSix.jsx";
+import StepSeven from "./step/StepSeven.jsx";
 import {useNavigate} from "react-router-dom";
 import MultiStepFormHeader from "./MultiStepFormHeader.jsx";
 import {useControlModal} from "../../hooks/useControlModal.js";
 import TipModal from "./modal/TipModal.jsx";
 import {tipSlides} from "../../constants/postNew/tipSlides.js";
-import StepSix from "./step/StepSix.jsx";
-import StepSeven from "./step/StepSeven.jsx";
+import StepThree from "./step/StepThree.jsx";
+import StepFour from "./step/StepFour.jsx";
 import {useSubmitFormData} from "../../hooks/mutation/useSubmitFormData.js";
 import {useEffect} from "react";
 import {useUserStore} from "../../store/useUserStore.js";
 
-const stepComponents = [StepOne, StepTwo, StepSix, StepSeven, StepThree, StepFour, StepFive];
+const stepComponents = [StepOne, StepTwo, StepThree, StepFour, StepFive, StepSix, StepSeven];
 
 const steps = stepComponents.map((Component, index) => (
     <Component key={index} />
@@ -28,15 +28,17 @@ function PostNewScreen() {
     const formData = useFormStore(state => state.formData);
     const storeId = useUserStore(state => state.user?.main_store_id);
 
+    const resetFormData = useFormStore(state => state.resetFormData);
     const updateFormData = useFormStore(state => state.updateFormData);
     const { modalState, openModal, closeModal } = useControlModal()
     const navigate = useNavigate();
 
     useEffect(() => {
+        resetFormData();
         updateFormData({
             store_id: storeId,
         })
-    },[])
+    },[storeId, resetFormData, updateFormData])
 
     const { mutate: submitForm } = useSubmitFormData({
         onSuccess: (data) => {
@@ -52,8 +54,8 @@ function PostNewScreen() {
         onError: (error) => {
             console.error("PostNewScreen: 최종 제출 실패", error);
             alert("게시물 생성에 실패했습니다. 다시 시도해주세요.");
-            // 실패 시 로딩 페이지에서 벗어나 다시 폼으로 돌아갈 수 있도록 처리
-            navigate('/post-new'); // 또는 이전 스텝으로 돌아가는 로직
+            resetFormData();
+            navigate('/post-new');
         }
     });
 
@@ -94,7 +96,6 @@ function PostNewScreen() {
 
     const handleNext = () => {
         nextStep(steps.length);
-        console.log("다음 단계로 이동");
     };
 
     const handleTagClick = () => {

--- a/src/components/postNew/step/StepFive.jsx
+++ b/src/components/postNew/step/StepFive.jsx
@@ -1,67 +1,42 @@
-import {useState} from "react";
 import useFormStore from "../../../store/useFormStore.js";
+import Sori from "../../../assets/sori1.svg";
 import styled from "styled-components";
-import UploadIcon from "../../../assets/upload.png";
+import PostButton from "../PostButton.jsx";
+import Webtoon from "../../../assets/webtoon.png";
+import TextImage from "../../../assets/Chat.png";
+import useSelectHandler from "../../../hooks/useSelectHandler.js";
 
+const options = [
+    { title: "이미지 + 텍스트", icon: TextImage, value: "image+text" },
+    { title: "네 컷 만화", icon: Webtoon, value: "cut_toon" },
+    { title: "문구 포함 이미지", icon: Webtoon, value: "post_cover+text" },
+];
 
 function StepFive() {
-    const {formData,updateFormData} = useFormStore();
-    const [previewImage, setPreviewImage] = useState(null);
-    const [text, setText] = useState("");
-
-    const handleTextChange = (e) => {
-        setText(e.target.value);
-        updateFormData({user_prompt: e.target.value});
-    }
-
-    const handleImageUpload = (e) => {
-        const file = e.target.files[0];
-        if (file) {
-            const reader = new FileReader();
-            reader.onloadend = () => {
-                setPreviewImage(reader.result);
-            };
-            reader.readAsDataURL(file);
-            updateFormData({user_image: file});
-        }
-    };
-
-    console.log(formData)
+    const { formData } = useFormStore();
+    const handleSelect = useSelectHandler("content_format");
 
     return (
         <Container>
-            <ImageSection>
-                <Title>어떤 이미지를 사용할까요?</Title>
-                <UploadButton htmlFor="image-upload">
-                    {!previewImage && (
-                        <>
-                            <UploadIconImage src={UploadIcon} alt="업로드 아이콘" />
-                            업로드하기
-                        </>
-                    )}
-                    {previewImage && <PreviewImage src={previewImage} alt="미리보기 이미지" />}
-                </UploadButton>
-                <FileInput
-                    id="image-upload"
-                    type="file"
-                    accept="image/*"
-                    onChange={handleImageUpload}
-                />
-            </ImageSection>
-            <TextSection>
-                <Title>추가 요청사항을 적어주세요!</Title>
-                <TextForm
-                    placeholder={"ex)고급스러운 느낌으로 만들어주세요"}
-                    onChange={handleTextChange}
-                    value={text}
-                />
-            </TextSection>
+            <Image src={Sori}/>
+            <Title>콘텐츠 형식을 선택해주세요!</Title>
+            <ButtonSection>
+                {options.map((option) => (
+                    <PostButton
+                        key={option.title}
+                        title={option.title}
+                        icon={option.icon}
+                        isSelected={formData.content_format === option.value}
+                        onClick={() => handleSelect(option.value)}
+                    />
+                ))}
+            </ButtonSection>
         </Container>
     );
 }
 
-
 export default StepFive;
+
 
 const Container = styled.div`
     display: flex;
@@ -69,48 +44,19 @@ const Container = styled.div`
     justify-content: flex-start;
     flex-direction: column;
     width: 100%;
-    padding: 0 3rem;
 `;
 
-const ImageSection = styled.div`
+const ButtonSection = styled.div`
+    width: 100%;
     display: flex;
-    align-items: center;
-    justify-content: center;
     flex-direction: column;
-    width: 100%;
-    gap: 1.5rem;
-`;
-
-const UploadButton = styled.label`
-    display: flex;
     align-items: center;
     justify-content: center;
-    width: 100%;
-    height: 30vh;
-    padding: 1rem 2rem;
-    background-color: #f0faf4;
-    border: none;
-    border-radius: 20px;
-    font-size: 20px;
-    font-weight: 600;
-    color: #074747;
-    cursor: pointer;
-    box-shadow: 0px 6px 4px rgba(0, 0, 0, 0.25);
+    gap: 20px;
+    padding-top: 2rem;
 `;
 
-const UploadIconImage = styled.img`
-    width: 17px;
-    height: 17px;
-    object-fit: contain;
-`;
-
-const FileInput = styled.input`
-    display: none;
-`;
-
-const PreviewImage = styled.img`
-    width: 100%;
-    height: 100%;
+const Image = styled.img`
     object-fit: contain;
 `;
 
@@ -119,28 +65,5 @@ const Title = styled.h1`
     font-weight: 600;
     text-align: center;
     width: 100%;
-    margin-top: 3rem;
-`;
-
-const TextSection = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    width: 100%;
-    gap: 1.5rem;
-`;
-
-const TextForm = styled.textarea`
-    width: 100%;
-    height: 20vh;
-    background-color: #f0faf4;
-    border: none;
-    border-radius: 20px;
-    font-size: 15px;
-    font-weight: 500;
-    color: #000000;
-    cursor: pointer;
-    padding: 1.5rem;
-    box-shadow: 0px 6px 4px rgba(0, 0, 0, 0.25);
+    padding-top: 3rem;
 `;

--- a/src/components/postNew/step/StepFour.jsx
+++ b/src/components/postNew/step/StepFour.jsx
@@ -1,43 +1,60 @@
 import useFormStore from "../../../store/useFormStore.js"
 import Sori from "../../../assets/sori1.svg"
 import styled from "styled-components"
+import useSelectHandler from "../../../hooks/useSelectHandler.js"
 import PostButton from "../PostButton.jsx"
-import Festival from "../../../assets/festival.png"
-import Weather from "../../../assets/weather.png"
-import Review from "../../../assets/review.png"
-import Trend from "../../../assets/trend.png"
-import useMultiSelectHandler from "../../../hooks/useMultiSelectHandler.js"
+import { Baby, GraduationCap, Users, Award } from 'lucide-react'
+
+const AgeIcons = {
+    "10-20": Baby,
+    "20-30": GraduationCap,
+    "30-40": Users,
+    "40+": Award
+}
 
 const options = [
-    { title: "날씨 정보", icon: Weather, value: "weather" },
-    { title: "리뷰 정보", icon: Review, value: "review" },
-    { title: "지역 행사", icon: Festival, value: "festival" },
-    { title: "트렌드", icon: Trend, value: "trend" },
+    {
+        title: "10~20세",
+        value: "10-20",
+        IconComponent: AgeIcons["10-20"]
+    },
+    {
+        title: "20~30세",
+        value: "20-30",
+        IconComponent: AgeIcons["20-30"]
+    },
+    {
+        title: "30~40세",
+        value: "30-40",
+        IconComponent: AgeIcons["30-40"]
+    },
+    {
+        title: "40세 이상",
+        value: "40+",
+        IconComponent: AgeIcons["40+"]
+    },
 ]
 
 function StepFour() {
     const { formData } = useFormStore()
-    const handleToggleSelect = useMultiSelectHandler("external_sources")
+    const handleSelect = useSelectHandler("age_range_target")
 
-    console.log(formData)
     return (
         <Container>
             <Image src={Sori || "/placeholder.svg"} alt="소리 캐릭터" />
-            <Title>어떤 정보를 포함할까요?</Title>
+            <Title>타겟 연령대를 선택해주세요</Title>
             <ButtonSection>
                 {options.map((option) => (
                     <PostButton
                         key={option.title}
                         title={option.title}
-                        icon={option.icon}
-                        isSelected={formData.external_sources?.includes(option.value)}
-                        onClick={() => handleToggleSelect(option.value)}
+                        icon={<option.IconComponent size={24} color="#FFFFFF" />}
+                        isSelected={formData.age_range_target === option.value}
+                        onClick={() => handleSelect(option.value)}
                         size="small"
-                        multiSelect={true}
                     />
                 ))}
             </ButtonSection>
-            <NoneButton onClick={() => handleToggleSelect("__CLEAR__")}>선택 안 할래요.</NoneButton>
         </Container>
     )
 }
@@ -55,9 +72,9 @@ const Container = styled.div`
 const ButtonSection = styled.div`
     width: 85%;
     display: grid;
-    grid-template-columns: repeat(2, 1fr); // 2개씩 한 줄에
+    grid-template-columns: repeat(2, 1fr);
     row-gap: 20px;
-    column-gap: 15px; // 버튼 사이 간격 추가
+    column-gap: 15px;
     padding-top: 3rem;
     justify-items: center;
 `
@@ -72,33 +89,4 @@ const Title = styled.h1`
     text-align: center;
     width: 100%;
     padding-top: 3rem;
-`
-
-const NoneButton = styled.button`
-    margin-top: 1.5rem;
-    background: none;
-    border: none;
-    color: #49c48f;
-    font-size: 1.1rem;
-    font-weight: 500;
-    cursor: pointer;
-    text-decoration: underline;
-    padding: 8px 16px;
-    border-radius: 8px;
-    transition: all 0.2s ease;
-
-    &:hover {
-        color: #3a8a63;
-        background-color: rgba(73, 196, 143, 0.05);
-    }
-
-    &:active {
-        color: #2f7c60;
-        transform: scale(0.98);
-    }
-
-    &:focus {
-        outline: 2px solid #49c48f;
-        outline-offset: 2px;
-    }
 `

--- a/src/components/postNew/step/StepSeven.jsx
+++ b/src/components/postNew/step/StepSeven.jsx
@@ -1,65 +1,67 @@
-import useFormStore from "../../../store/useFormStore.js"
-import Sori from "../../../assets/sori1.svg"
-import styled from "styled-components"
-import useSelectHandler from "../../../hooks/useSelectHandler.js"
-import PostButton from "../PostButton.jsx"
-import { Baby, GraduationCap, Users, Award } from 'lucide-react'
+import {useState} from "react";
+import useFormStore from "../../../store/useFormStore.js";
+import styled from "styled-components";
+import UploadIcon from "../../../assets/upload.png";
 
-const AgeIcons = {
-    "10-20": Baby,
-    "20-30": GraduationCap,
-    "30-40": Users,
-    "40+": Award
-}
-
-const options = [
-    {
-        title: "10~20세",
-        value: "10-20",
-        IconComponent: AgeIcons["10-20"]
-    },
-    {
-        title: "20~30세",
-        value: "20-30",
-        IconComponent: AgeIcons["20-30"]
-    },
-    {
-        title: "30~40세",
-        value: "30-40",
-        IconComponent: AgeIcons["30-40"]
-    },
-    {
-        title: "40세 이상",
-        value: "40+",
-        IconComponent: AgeIcons["40+"]
-    },
-]
 
 function StepSeven() {
-    const { formData } = useFormStore()
-    const handleSelect = useSelectHandler("age_range_target")
+    const {formData,updateFormData} = useFormStore();
+    const [previewImage, setPreviewImage] = useState(null);
+    const [text, setText] = useState("");
+
+    const handleTextChange = (e) => {
+        setText(e.target.value);
+        updateFormData({user_prompt: e.target.value});
+    }
+
+    const handleImageUpload = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onloadend = () => {
+                setPreviewImage(reader.result);
+            };
+            reader.readAsDataURL(file);
+            updateFormData({user_image: file});
+        }
+    };
+
+    console.log(formData)
 
     return (
         <Container>
-            <Image src={Sori || "/placeholder.svg"} alt="소리 캐릭터" />
-            <Title>타겟 연령대를 선택해주세요</Title>
-            <ButtonSection>
-                {options.map((option) => (
-                    <PostButton
-                        key={option.title}
-                        title={option.title}
-                        icon={<option.IconComponent size={24} color="#FFFFFF" />}
-                        isSelected={formData.age_range_target === option.value}
-                        onClick={() => handleSelect(option.value)}
-                        size="small"
-                    />
-                ))}
-            </ButtonSection>
+            <ImageSection>
+                <Title>어떤 이미지를 사용할까요?</Title>
+                <UploadButton htmlFor="image-upload">
+                    {!previewImage && (
+                        <>
+                            <UploadIconImage src={UploadIcon} alt="업로드 아이콘" />
+                            업로드하기
+                        </>
+                    )}
+                    {previewImage && <PreviewImage src={previewImage} alt="미리보기 이미지" />}
+                </UploadButton>
+                <FileInput
+                    id="image-upload"
+                    type="file"
+                    accept="image/*"
+                    onChange={handleImageUpload}
+                />
+            </ImageSection>
+            <TextSection>
+                <Title>추가 요청사항을 적어주세요!</Title>
+                <TextForm
+                    placeholder={"ex)고급스러운 느낌으로 만들어주세요"}
+                    onChange={handleTextChange}
+                    value={text}
+                />
+            </TextSection>
         </Container>
-    )
+    );
 }
 
-export default StepSeven
+
+export default StepSeven;
 
 const Container = styled.div`
     display: flex;
@@ -67,26 +69,78 @@ const Container = styled.div`
     justify-content: flex-start;
     flex-direction: column;
     width: 100%;
-`
+    padding: 0 3rem;
+`;
 
-const ButtonSection = styled.div`
-    width: 85%;
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    row-gap: 20px;
-    column-gap: 15px;
-    padding-top: 3rem;
-    justify-items: center;
-`
+const ImageSection = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    width: 100%;
+    gap: 1.5rem;
+`;
 
-const Image = styled.img`
+const UploadButton = styled.label`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 30vh;
+    padding: 1rem 2rem;
+    background-color: #f0faf4;
+    border: none;
+    border-radius: 20px;
+    font-size: 20px;
+    font-weight: 600;
+    color: #074747;
+    cursor: pointer;
+    box-shadow: 0px 6px 4px rgba(0, 0, 0, 0.25);
+`;
+
+const UploadIconImage = styled.img`
+    width: 17px;
+    height: 17px;
     object-fit: contain;
-`
+`;
+
+const FileInput = styled.input`
+    display: none;
+`;
+
+const PreviewImage = styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+`;
 
 const Title = styled.h1`
     font-size: 23px;
     font-weight: 600;
     text-align: center;
     width: 100%;
-    padding-top: 3rem;
-`
+    margin-top: 3rem;
+`;
+
+const TextSection = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    width: 100%;
+    gap: 1.5rem;
+`;
+
+const TextForm = styled.textarea`
+    width: 100%;
+    height: 20vh;
+    background-color: #f0faf4;
+    border: none;
+    border-radius: 20px;
+    font-size: 15px;
+    font-weight: 500;
+    color: #000000;
+    cursor: pointer;
+    padding: 1.5rem;
+    box-shadow: 0px 6px 4px rgba(0, 0, 0, 0.25);
+`;

--- a/src/components/postNew/step/StepSix.jsx
+++ b/src/components/postNew/step/StepSix.jsx
@@ -1,42 +1,47 @@
-import useFormStore from "../../../store/useFormStore.js";
-import Sori from "../../../assets/sori1.svg";
-import styled from "styled-components";
-import PostButton from "../PostButton.jsx";
-import Man from "../../../assets/man.svg";
-import Woman from "../../../assets/woman.svg";
-import useSelectHandler from "../../../hooks/useSelectHandler.js";
+import useFormStore from "../../../store/useFormStore.js"
+import Sori from "../../../assets/sori1.svg"
+import styled from "styled-components"
+import PostButton from "../PostButton.jsx"
+import Festival from "../../../assets/festival.png"
+import Weather from "../../../assets/weather.png"
+import Review from "../../../assets/review.png"
+import Trend from "../../../assets/trend.png"
+import useMultiSelectHandler from "../../../hooks/useMultiSelectHandler.js"
 
 const options = [
-    {title: "여성", icon: Woman, value:"female"},
-    {title: "남성", icon: Man, value: "male"},
-];
+    { title: "날씨 정보", icon: Weather, value: "weather" },
+    { title: "리뷰 정보", icon: Review, value: "review" },
+    { title: "지역 행사", icon: Festival, value: "festival" },
+    { title: "트렌드", icon: Trend, value: "trend" },
+]
 
 function StepSix() {
-    const {formData} = useFormStore();
-    const handleSelect = useSelectHandler("gender_target");
+    const { formData } = useFormStore()
+    const handleToggleSelect = useMultiSelectHandler("external_sources")
 
-    console.log(formData);
     return (
         <Container>
-            <Image src={Sori}/>
-            <Title>타겟층을 선택해주세요!</Title>
+            <Image src={Sori || "/placeholder.svg"} alt="소리 캐릭터" />
+            <Title>어떤 정보를 포함할까요?</Title>
             <ButtonSection>
                 {options.map((option) => (
                     <PostButton
                         key={option.title}
                         title={option.title}
                         icon={option.icon}
-                        isSelected={formData.gender_target === option.value}
-                        onClick={() => handleSelect(option.value)}
+                        isSelected={formData.external_sources?.includes(option.value)}
+                        onClick={() => handleToggleSelect(option.value)}
+                        size="small"
+                        multiSelect={true}
                     />
                 ))}
             </ButtonSection>
+            <NoneButton onClick={() => handleToggleSelect("__CLEAR__")}>선택 안 할래요.</NoneButton>
         </Container>
-    );
+    )
 }
 
-export default StepSix;
-
+export default StepSix
 
 const Container = styled.div`
     display: flex;
@@ -44,21 +49,21 @@ const Container = styled.div`
     justify-content: flex-start;
     flex-direction: column;
     width: 100%;
-`;
+`
 
 const ButtonSection = styled.div`
-    width: 100%;
-    display: flex;
-    flex-direction: column;
+    width: 85%;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr); // 2개씩 한 줄에
+    row-gap: 20px;
+    column-gap: 15px; // 버튼 사이 간격 추가
+    padding-top: 3rem;
     justify-items: center;
-    align-items: center;
-    padding: 2rem;
-    gap: 2rem;
-`;
+`
 
 const Image = styled.img`
     object-fit: contain;
-`;
+`
 
 const Title = styled.h1`
     font-size: 23px;
@@ -66,4 +71,33 @@ const Title = styled.h1`
     text-align: center;
     width: 100%;
     padding-top: 3rem;
-`;
+`
+
+const NoneButton = styled.button`
+    margin-top: 1.5rem;
+    background: none;
+    border: none;
+    color: #49c48f;
+    font-size: 1.1rem;
+    font-weight: 500;
+    cursor: pointer;
+    text-decoration: underline;
+    padding: 8px 16px;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+
+    &:hover {
+        color: #3a8a63;
+        background-color: rgba(73, 196, 143, 0.05);
+    }
+
+    &:active {
+        color: #2f7c60;
+        transform: scale(0.98);
+    }
+
+    &:focus {
+        outline: 2px solid #49c48f;
+        outline-offset: 2px;
+    }
+`

--- a/src/components/postNew/step/StepThree.jsx
+++ b/src/components/postNew/step/StepThree.jsx
@@ -2,32 +2,30 @@ import useFormStore from "../../../store/useFormStore.js";
 import Sori from "../../../assets/sori1.svg";
 import styled from "styled-components";
 import PostButton from "../PostButton.jsx";
-import Webtoon from "../../../assets/webtoon.png";
-import TextImage from "../../../assets/Chat.png";
+import Man from "../../../assets/man.svg";
+import Woman from "../../../assets/woman.svg";
 import useSelectHandler from "../../../hooks/useSelectHandler.js";
 
 const options = [
-    { title: "이미지 + 텍스트", icon: TextImage, value: "image+text" },
-    { title: "네 컷 만화", icon: Webtoon, value: "cut_toon" },
-    { title: "문구 포함 이미지", icon: Webtoon, value: "post_cover+text" },
+    {title: "여성", icon: Woman, value:"female"},
+    {title: "남성", icon: Man, value: "male"},
 ];
 
 function StepThree() {
-    const { formData } = useFormStore();
-    const handleSelect = useSelectHandler("content_format");
-    console.log(formData);
+    const {formData} = useFormStore();
+    const handleSelect = useSelectHandler("gender_target");
 
     return (
         <Container>
             <Image src={Sori}/>
-            <Title>콘텐츠 형식을 선택해주세요!</Title>
+            <Title>타겟층을 선택해주세요!</Title>
             <ButtonSection>
                 {options.map((option) => (
                     <PostButton
                         key={option.title}
                         title={option.title}
                         icon={option.icon}
-                        isSelected={formData.content_format === option.value}
+                        isSelected={formData.gender_target === option.value}
                         onClick={() => handleSelect(option.value)}
                     />
                 ))}
@@ -51,10 +49,10 @@ const ButtonSection = styled.div`
     width: 100%;
     display: flex;
     flex-direction: column;
+    justify-items: center;
     align-items: center;
-    justify-content: center;
-    gap: 20px;
-    padding-top: 2rem;
+    padding: 2rem;
+    gap: 2rem;
 `;
 
 const Image = styled.img`

--- a/src/components/postNew/step/StepTwo.jsx
+++ b/src/components/postNew/step/StepTwo.jsx
@@ -16,8 +16,6 @@ function StepTwo() {
     const { formData, updateFormData } = useFormStore();
     const handleSelect = useSelectHandler("promotion_target");
 
-    console.log(formData);
-
     return (
         <Container>
             <Image src={Sori}/>

--- a/src/store/useFormStore.js
+++ b/src/store/useFormStore.js
@@ -26,8 +26,10 @@ const useFormStore = create((set) => ({
     })),
 
     resetFormData: () => set({
+        currentStepIndex: 0,
         formData: initialFormData
     }),
+
     tempContentId: null,
     setTempContentId: (id) => set({ tempContentId: id }),
 


### PR DESCRIPTION
변경한 이유:
- 사용자 경험을 향상시키고 폼 상태 관리의 일관성을 확보하기 위함.
- 마이페이지 UI, 게시글 생성 폼 초기화, 헤더 겹침 문제 등 여러 UX/UI 관련 불편 사항을 해결. 변경 내용:
- 마이페이지에서 이름과 대표 가게 항목 간의 간격을 조정하여 가독성 개선
- 이름 수정 완료 시 자동으로 이전 페이지로 돌아가도록 라우팅 로직 추가
- 게시글 생성 성공 후 다시 폼으로 진입 시 currentStepIndex를 1단계(StepOne)로 초기화하고 폼 데이터를 리셋하도록 수정
- 기록 보기 및 기록 상세보기 페이지에서 헤더가 겹쳐 보이던 문제를 화면 vh 조정으로 해결

